### PR TITLE
Fix: Deploying the project changes the custom URL to the GitHub default URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite build && vite preview",
-    "deploy": "vite build && gh-pages -d dist"
+    "deploy": "vite build && gh-pages -d dist --cname danielcortes.tech"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",


### PR DESCRIPTION
### Description
Deploying the project trough gh-pages changes the custom URL danielcortes.tech to the GitHub default danieldevcode.github.io/portfolio

### Fix
- Added the cname option to the deploy script

### Issue #4